### PR TITLE
change all long to int in feffpath C wrapper

### DIFF
--- a/src/GENFMT/feffpath.c
+++ b/src/GENFMT/feffpath.c
@@ -13,10 +13,10 @@
 
 #include "feffpath.h"
 
-_EXPORT(long) create_path(FEFFPATH *path) {
+_EXPORT(int) create_path(FEFFPATH *path) {
   /* Instantiate and initialize a FEFFPATH struct */
   /* Return an error code -- currently hardwired to return 0. */
-  long i;
+  int i;
   char message[500] = {'\0'};
   char phpad[257] = {'\0'};
   char exch[9] = {'\0'};
@@ -61,8 +61,8 @@ _EXPORT(long) create_path(FEFFPATH *path) {
   for (i = 0; i < legtot+2; i++) {
     path->rat[i] = calloc(3, sizeof(double));
   }
-  path->iz       = calloc(nphx+1,   sizeof(long));
-  path->ipot     = calloc(legtot+1, sizeof(long));
+  path->iz       = calloc(nphx+1,   sizeof(int));
+  path->ipot     = calloc(legtot+1, sizeof(int));
   path->ri       = calloc(legtot,   sizeof(double));
   path->beta     = calloc(legtot+1, sizeof(double));
   path->eta      = calloc(legtot+2, sizeof(double));
@@ -92,7 +92,7 @@ _EXPORT(long) create_path(FEFFPATH *path) {
 _EXPORT(void) clear_path(FEFFPATH *path) {
   /* Reinitialize a FEFFPATH struct, returning everything to default */
   /* except phpad, verbose, nnnn, and json. */
-  long i,j;
+  int i,j;
   /* char phpad[256] = {'\0'}; */
   /* sprintf(phpad, "%-256s", " "); */
 
@@ -157,33 +157,33 @@ _EXPORT(void) clear_path(FEFFPATH *path) {
 }
 
 
-_EXPORT(long) make_path(FEFFPATH *path) {
+_EXPORT(int) make_path(FEFFPATH *path) {
   /* Compute the path using the content of the FEFFPATH struct.*/
   /* Fill the struct with geometry and F_eff information. */
   /* Return an error code. */
-  long i, j;
-  long error = 0;
+  int i, j;
+  int error = 0;
 
   /* scattering and path geometry */
-  long index, iorder, nleg;
+  int index, iorder, nleg;
   double degen;
-  long ipot[legtot+1], iz[nphx+1];
+  int ipot[legtot+1], iz[nphx+1];
   double rat[legtot+2][3];
   double ri[legtot], beta[legtot+1], eta[legtot+2];
 
   /* potentials parameters */
-  long ixc;
+  int ixc;
   double rs, vint, mu, edge, kf, rnrmav, gamach;
 
   /* onepath.f output */
-  long nnnn, json, verbose;
+  int nnnn, json, verbose;
 
   /* feffNNNN.dat columns */
-  long ne;
+  int ne;
   double k[nex], real_phc[nex], mag_feff[nex], pha_feff[nex], red_fact[nex], lam[nex], rep[nex];
 
   /* polarization and ellipticity */
-  long ipol;
+  int ipol;
   double elpty;
   double evec[3];
   double xivec[3];
@@ -244,7 +244,7 @@ _EXPORT(long) make_path(FEFFPATH *path) {
   };
   path->errorcode = error;
   make_path_errorstring(path);
-  /* printf("%ld\n", path->errorcode); */
+  /* printf("%d\n", path->errorcode); */
   /* fflush(stdout); */
   if (error > 0) {
     return error;
@@ -316,12 +316,12 @@ _EXPORT(long) make_path(FEFFPATH *path) {
   return error;
 }
 
-_EXPORT(long) add_scatterer(FEFFPATH *path, double x, double y, double z, long ip) {
+_EXPORT(int) add_scatterer(FEFFPATH *path, double x, double y, double z, int ip) {
   /* Add a scattering atom to the path. Fill the nleg member. */
   /* Return an error code. */
-  long error;
+  int error;
   double length;
-  long nleg = path->nleg;
+  int nleg = path->nleg;
   if (nleg == 0) {nleg = 1;}
   nleg = nleg + 1;
 
@@ -353,7 +353,7 @@ _EXPORT(long) add_scatterer(FEFFPATH *path, double x, double y, double z, long i
 
 _EXPORT(void) cleanup(FEFFPATH *path) {
   /* one needs to explicitly free each part of the struct */
-  long i;
+  int i;
 
   for (i = 0; i < legtot+2; i++) {
     free(path->rat[i]);
@@ -386,7 +386,7 @@ _EXPORT(void) cleanup(FEFFPATH *path) {
 
 double leglength(FEFFPATH *path) {
   double x1, y1, z1, x2, y2, z2;
-  long nleg = path->nleg;
+  int nleg = path->nleg;
   x1 = path->rat[nleg-2][0];
   y1 = path->rat[nleg-2][1];
   z1 = path->rat[nleg-2][2];
@@ -400,18 +400,18 @@ double leglength(FEFFPATH *path) {
 /* error string interpretation */
 void make_scatterer_errorstring(FEFFPATH *path) {
   double x, y, z;
-  long ip;
+  int ip;
   char message[500];
   char error[100];
-  long errcode = path->errorcode;
-  long nleg = path->nleg;
+  int errcode = path->errorcode;
+  int nleg = path->nleg;
   x  = path->rat[nleg-1][0];
   y  = path->rat[nleg-1][1];
   z  = path->rat[nleg-1][2];
   ip = path->ipot[nleg-1];
 
   if (errcode == 0) { return; }
-  sprintf(message, "Error in add_scatterer at atom (%.5f, %.5f, %.5f, %ld):\n", x, y, z, ip);
+  sprintf(message, "Error in add_scatterer at atom (%.5f, %.5f, %.5f, %d):\n", x, y, z, ip);
   if (errcode & ERR_NEGIPOT) {
     strcpy(error, "\t(code 1) ipot argument to add_scatterer is less than 0\n");
     strcat(message, error);
@@ -433,11 +433,11 @@ void make_scatterer_errorstring(FEFFPATH *path) {
 
 void make_path_errorstring(FEFFPATH *path) {
   double degen, elpty;
-  long index, iorder;
+  int index, iorder;
   char message[500];
   char error[100];
-  long errcode = path->errorcode;
-  long nleg = path->nleg;
+  int errcode = path->errorcode;
+  int nleg = path->nleg;
   char phpad[256] = {'\0'};
   degen  = path->degen;
   index  = path->index;
@@ -460,7 +460,7 @@ void make_path_errorstring(FEFFPATH *path) {
     strcat(message, error);
   };
   if (errcode & ERR_BADINDEX) {
-    sprintf(error, "\t(code 8) path index (%ld) not between 0 and 9999\n", index);
+    sprintf(error, "\t(code 8) path index (%d) not between 0 and 9999\n", index);
     strcat(message, error);
   };
   if (errcode & ERR_BADELPTY) {
@@ -468,7 +468,7 @@ void make_path_errorstring(FEFFPATH *path) {
     strcat(message, error);
   };
   if (errcode & ERR_BADIORDER) {
-    sprintf(error, "\t(code 32) iorder (%ld) not between 0 and 10\n", iorder);
+    sprintf(error, "\t(code 32) iorder (%d) not between 0 and 10\n", iorder);
     strcat(message, error);
   };
   if (errcode & ERR_NOPHPAD) {

--- a/src/GENFMT/feffpath.h
+++ b/src/GENFMT/feffpath.h
@@ -39,12 +39,12 @@ typedef struct {
   char *phpad;
 
   /* INPUT: structure of path                                                        */
-  long index;         /* path index                                default = 9999    */
-  long nleg;          /* number of legs in path                    use add_scatterer */
+  int index;         /* path index                                default = 9999    */
+  int nleg;          /* number of legs in path                    use add_scatterer */
   double degen;       /* path degeneracy                           must be supplied  */
   double **rat;       /* cartesian positions of atoms in path      use add_scatterer */
-  long *ipot;         /* unique potentials of atoms in path        use add_scatterer */
-  long iorder;        /* order of approximation in genfmt          default = 2       */
+  int *ipot;         /* unique potentials of atoms in path        use add_scatterer */
+  int iorder;        /* order of approximation in genfmt          default = 2       */
 
   /* INPUT: output flags for saving F_eff to a file                                  */
   bool nnnn;          /* flag to write feffNNNN.dat file           default = false   */
@@ -69,14 +69,14 @@ typedef struct {
   char *version;      /* Feff version                                                */
 
   /* OUTPUT: geometry information (leg length, beta, eta, Z)                         */
-  long *iz;           /* atomic numbers of atoms in path     obtained from phase.pad */
+  int *iz;           /* atomic numbers of atoms in path     obtained from phase.pad */
   double *ri;         /* leg lengths                                                 */
   double *beta;       /* beta angles                                                 */
   double *eta;        /* eta angles                                                  */
   double reff;        /* half path length                          computed from ri  */
 
   /* OUTPUT: columns of feffNNNN.dat                                                 */
-  long ne;            /* number of energy points actually used by Feff               */
+  int ne;            /* number of energy points actually used by Feff               */
   double *k;          /* k grid for feff path calculation   column 1 in feffNNNN.dat */
   double *real_phc;   /* central atom phase shifts          column 2 in feffNNNN.dat */
   double *mag_feff;   /* magnitude of F_eff                 column 3 in feffNNNN.dat */
@@ -86,7 +86,7 @@ typedef struct {
   double *rep;        /* real part of complex momentum      column 7 in feffNNNN.dat */
 
   /* OUTPUT: error handling                                                          */
-  long errorcode;     /* error code from add_scatterer or make_path                  */
+  int errorcode;     /* error code from add_scatterer or make_path                  */
   char *errormessage; /* error code from add_scatterer or make_path                  */
 } FEFFPATH;
 
@@ -106,20 +106,20 @@ typedef struct {
 /*    - vint          interstitial potential                                                                       */
 /* --------------------------------------------------------------------------------------------------------------- */
 
-long add_scatterer(FEFFPATH*, double, double, double, long);
-long create_path(FEFFPATH*);
+int add_scatterer(FEFFPATH*, double, double, double, int);
+int create_path(FEFFPATH*);
 void clear_path(FEFFPATH*);
-long make_path(FEFFPATH*);
+int make_path(FEFFPATH*);
 void cleanup(FEFFPATH*);
 void make_path_errorstring(FEFFPATH*);
 void make_scatterer_errorstring(FEFFPATH*);
 double leglength(FEFFPATH*);
 
 void onepath_(char *,                   /* path to phase.pad file */
-	      long *,                   /* path index */
-	      long *,                   /* nlegs */
+	      int *,                    /* path index */
+	      int *,                    /* nlegs */
 	      double *,                 /* degeneracy */
-	      long *,                   /* iorder */
+	      int *,                    /* iorder */
 	      char *,                   /* exch, potential model description */
 	      double *,                 /* rs, interstitial radius estimate */
 	      double *,                 /* vint, interstitial potential energy */
@@ -130,23 +130,23 @@ void onepath_(char *,                   /* path to phase.pad file */
 	      double *,                 /* gamach, chore hole lifetime in eV */
 	      char *,                   /* version, Feff's versioning string */
 	      /* scattering geometry */
-	      long (*)[legtot+1],       /* list of unique potentials */
+	      int (*)[legtot+1],        /* list of unique potentials */
 	      double (*)[legtot+2][3],  /* list of cartesian coordinates */
-	      long (*)[nphx+1],         /* list of atomic numbers */
+	      int (*)[nphx+1],          /* list of atomic numbers */
 	      /* polarization and ellipticity */
-	      long *,                   /* flag to compute polarization */
+	      int *,                    /* flag to compute polarization */
 	      double (*)[3],            /* polarization vector */
 	      double *,                 /* ellipticity */
 	      double (*)[3],            /* direction of travel */
 	      /* output flags */
-	      long *,                   /* integer flag for writing feffNNNN.dat */
-	      long *,                   /* integer flag for writing feffNNNN.json */
-	      long *,                   /* integer flag for writing screen messages */
+	      int *,                    /* integer flag for writing feffNNNN.dat */
+	      int *,                    /* integer flag for writing feffNNNN.json */
+	      int *,                    /* integer flag for writing screen messages */
 	      /* path geometry */
 	      double (*)[legtot],       /* Ri   */
 	      double (*)[legtot+1],     /* beta */
 	      double (*)[legtot+2],     /* eta  */
-	      long *,                   /* number of points in kgrid */
+	      int *,                    /* number of points in kgrid */
 	      /* seven columns of feffNNNN.dat file */
 	      double (*)[nex], double (*)[nex], double (*)[nex], double (*)[nex], double (*)[nex], double (*)[nex], double (*)[nex]);
 

--- a/src/GENFMT/feffpath.i
+++ b/src/GENFMT/feffpath.i
@@ -48,7 +48,7 @@
     else return path->xivec[index];
   }
 
-  long get_iz(FEFFPATH *path, int index) {
+  int get_iz(FEFFPATH *path, int index) {
     if ((index < 0) || (index >= nphx)) return -1;
     else return path->iz[index];
   }

--- a/wrappers/C/makepath.c
+++ b/wrappers/C/makepath.c
@@ -3,9 +3,9 @@
 
 #include "feffpath.h"
 
-long main()
+int main()
 {
-  long i, ret;
+  int i, ret;
   FEFFPATH *path;
 
   path = malloc(sizeof(FEFFPATH));
@@ -23,7 +23,7 @@ long main()
   ret = make_path(path);
 
   /* for (i=0; i<nphx; i++) { */
-  /*   printf(" %ld  %ld\n", i, path->iz[i]); */
+  /*   printf(" %d  %d\n", i, path->iz[i]); */
   /* }; */
 
   clear_path(path);


### PR DESCRIPTION
In the C interface to the feff path calculator, change all instances of long intergers to normal integers.  See #24.