### PR TITLE
Tests refactor py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 export PREFIX  = /usr/local
-## export PREFIX  = ${HOME}/.local
+# export PREFIX  = ${HOME}/local
 
 export BASEDIR = ${CURDIR}
 export BINDIR  = $(PREFIX)/bin		# installation location for programs

--- a/tests/f85ut.py
+++ b/tests/f85ut.py
@@ -11,20 +11,29 @@ import numpy     as np
 import importlib
 from   distutils.spawn import find_executable
 
-from larch import (Group, Parameter, isParameter, param_value, use_plugin_path, isNamedClass, Interpreter)
-use_plugin_path('xafs')
-from feffdat import feffpath
-from feffrunner import feffrunner
-use_plugin_path('wx')
-from plotter import (_newplot, _plot)
+from larch import (Group, Parameter, isParameter, param_value,
+                   isNamedClass, Interpreter)
+from larch_plugins.xafs.feffdat import feffpath
+from larch_plugins.xafs.feffrunner import feffrunner
+from larch_plugins.xafs.feff8lpath import Feff8L_XAFSPath
+from larch_plugins.wx import (_newplot, _plot)
 
 
+WARN_COLOR = 'yellow'
+WARN_COLOR = 'blue'
 
-wrapper_available=True
-try:
-    from scatteringpath import scatpath
-except ImportError:
-    wrapper_available=False
+def print_error(text):
+    print(colored(text, 'magenta', attrs=['bold']))
+
+def print_warn(text):
+    print(colored(text, WARN_COLOR, attrs=['bold']))
+
+def print_good(text):
+    print(colored(text, 'green', attrs=['bold']))
+
+def test_text(text, cond):
+    color = 'green' if cond else 'magenta'
+    return colored(text, color, attrs=['bold'])
 
 class Feff85exafsUnitTestGroup(Group):
     """
@@ -62,7 +71,7 @@ class Feff85exafsUnitTestGroup(Group):
        epsilon   :  float,   value for comparing columns from feffNNNN.dat with the baseline and other things
        count     \\
        datacount  > integers, used to count number of tests run
-       feffcount / 
+       feffcount /
     """
 
     def __init__(self, folder=None, _larch=None, **kws):
@@ -70,7 +79,7 @@ class Feff85exafsUnitTestGroup(Group):
         kwargs.update(kws)
         Group.__init__(self,  **kwargs)
         self._larch     = Interpreter()
-        self.doplot     = True  
+        self.doplot     = True
         self.doscf      = False # True = use self-consistency
         self.verbose    = True  # True = print Feff's screen messages and other screen messages
         self.feffran    = False # True = Feff calculation has been run
@@ -84,7 +93,7 @@ class Feff85exafsUnitTestGroup(Group):
         if not isdir(folder):
             folder = join('tests', folder)
         if not isdir(folder):
-            print colored(folder + " isn't one of the available tests", 'magenta', attrs=['bold'])
+            print_error(folder + " isn't one of the available tests")
             return None
 
         self.path       = realpath(folder)
@@ -101,29 +110,27 @@ class Feff85exafsUnitTestGroup(Group):
         self.epsfit     = self.eps3
         self.firstshell = False
         self.fittest    = None
-        self.wrapper_available = wrapper_available
-        if wrapper_available:
-            self.sp = scatpath()
-        
-        
+        self.sp = Feff8L_XAFSPath(_larch=self._larch)
+
+
     def __repr__(self):
         if not isdir(self.folder):
             return '<Feff85exafs Unit Test Group (empty)>'
         if self.folder is not None:
             return '<Feff85exafs Unit Test Group: %s>' % self.folder
         return '<Feff85exafs Unit Test Group (empty)>'
-        
-        
+
+
     @property
     def baseline(self):
         scf = 'withSCF' if self.doscf else 'noSCF'
         return realpath(join(self.path, 'baseline', scf))
-        
+
     @property
     def bpaths(self):
         """
         Gather a list of feffNNNN.dat files from the baseline calculation
-        
+
         """
         p   = list()
         owd = getcwd()
@@ -137,7 +144,7 @@ class Feff85exafsUnitTestGroup(Group):
         finally:
             chdir(owd)
         return p
-        
+
     def run(self):
         """
         Make a feff.inp from the mustache template, then run feff 8.5 in
@@ -145,7 +152,7 @@ class Feff85exafsUnitTestGroup(Group):
 
         """
         if not isdir(self.path):
-            print colored(self.folder + " is not one of the available tests", 'magenta', attrs=['bold'])
+            print_error(self.folder + " is not one of the available tests")
             return False
 
         ## clean up an earlier run
@@ -174,9 +181,11 @@ class Feff85exafsUnitTestGroup(Group):
             self.feffrunner=feffrunner(feffinp=join(self.testrun,'feff.inp'), verbose=self.verbose, repo=self.repotop, _larch=self._larch)
             self.feffrunner.run()
             for f in glob.glob("*"):
-                if f.startswith('log'): unlink(f)
-            
-            if self.verbose: print colored("\nRan Feff85EXAFS on %s (%s)" % (self.folder, scf), 'yellow', attrs=['bold'])
+                if f.startswith('log'):
+                    unlink(f)
+
+            if self.verbose:
+                print_warn("\nRan Feff85EXAFS on %s (%s)" % (self.folder, scf))
             self.__testpaths()
         finally:
             chdir(owd)
@@ -184,7 +193,7 @@ class Feff85exafsUnitTestGroup(Group):
 
     def run_opconsat(self):
         if not self.feffran:
-            print colored("You need to run the rest of the feff calculation first.", 'magenta', attrs=['bold'])
+            print_error("You need to run the rest of the feff calculation first.")
             return False
         ## run feff with feffrunner
         owd = getcwd()
@@ -196,10 +205,10 @@ class Feff85exafsUnitTestGroup(Group):
         finally:
             chdir(owd)
         if not isfile(join(self.testrun, "exc.dat")):
-            print colored("Failed to run opconsat.", 'magenta', attrs=['bold'])
+            print_error("Failed to run opconsat.")
             return False
         return True
-            
+
     def __testpaths(self):
         """
         Gather a list of feffNNNN.dat files from the testrun
@@ -218,8 +227,8 @@ class Feff85exafsUnitTestGroup(Group):
                 self.feffran = True
             finally:
                 chdir(owd)
-            
-            
+
+
     def available(self, which=0):
         """
         Test whether a path index was included in the test calculation.
@@ -244,7 +253,7 @@ class Feff85exafsUnitTestGroup(Group):
             for f in self.paths:
                 print "\t"+f
             return None
-            
+
 
     def __snarf_geometry(self, index=1):
         pathsdat = self.testrun+'/paths.dat'
@@ -280,9 +289,12 @@ class Feff85exafsUnitTestGroup(Group):
                     continue
                 else:
                     words = line.split()
-                    self.sp.atom(float(words[0]), float(words[1]), float(words[2]), int(words[3]))
+                    self.sp.add_scatterer(x=float(words[0]),
+                                          y=float(words[1]),
+                                          z=float(words[2]),
+                                          ipot=int(words[3]))
                     count+=1
-            
+
     def compare(self, nnnn=1, part='feff', use_wrapper=False, _larch=None):
         """
         Compare a feffNNNN.dat file from the testrun with the same file
@@ -290,13 +302,13 @@ class Feff85exafsUnitTestGroup(Group):
 
             group.compare(N, part, use_wrapper)
 
-        where N is the path index, part is one of 
+        where N is the path index, part is one of
             feff    :      test the magnitude AND phase of F_eff (default)
             amp     :      test the total amplitude of the path
             phase   :      test the total phase of the path
-            lambda  :      test the mean free path
+            lam     :      test the mean free path
             caps    :      test the central atom phase shift
-            redfact :      test the reduction factor
+            red_fact:      test the reduction factor
             rep     :      test the real part of the complex wavenumber
 
         and use_wrapper is True if the test is to use the python interface to
@@ -308,21 +320,21 @@ class Feff85exafsUnitTestGroup(Group):
         """
         if self._larch is None:
             raise Warning("cannot do path comparison -- larch broken?")
-            
+
         if not self.feffran:
-            print colored("You have not yet run the test Feff calculation", 'magenta', attrs=['bold'])
+            print_error("You have not yet run the test Feff calculation")
             return
-            
+
         if not self.available(nnnn):
-            print colored("Path %d was not saved from the test Feff calculation" % nnnn, 'magenta', attrs=['bold'])
+            print_error("Path %d was not saved from the test Feff calculation" % nnnn)
             return
-            
+
         how     = 'wrapper' if use_wrapper else 'executables'
         nnnndat = "feff%4.4d.dat" % nnnn
-        
+
         blpath = feffpath(join(self.baseline, nnnndat))
-        if use_wrapper and self.wrapper_available: # make the f3ffNNNN.dat file on the fly
-            self.sp.phpad=join(self.testrun, 'phase.pad')
+        if use_wrapper: # make the feffNNNN.dat file on the fly
+            self.sp.phase_file = join(self.testrun, 'phase.pad')
             self.sp.nnnn=True
             self.sp.index=nnnn
             self.sp.verbose=self.verbose
@@ -330,42 +342,42 @@ class Feff85exafsUnitTestGroup(Group):
             owd = getcwd()
             try:
                 chdir(self.testrun)
-                self.sp.make()
+                self.sp.calculate_xafs()
             finally:
                 chdir(owd)
-            n3nndat = "f3ff%4.4d.dat" % nnnn
+            n3nndat = "feff%4.4d.dat" % nnnn
             trpath = feffpath(join(self.testrun,  n3nndat))
         else:                   # the feffNNNN.dat file was made by the monolithic feff run
             trpath = feffpath(join(self.testrun,  nnnndat))
-        
+
         if part=='feff':
             baseline_1 = getattr(blpath._feffdat, 'mag_feff') # + np.random.uniform(0,1,size=1)
             testrun_1  = getattr(trpath._feffdat, 'mag_feff')
             baseline_2 = getattr(blpath._feffdat, 'pha_feff') # + np.random.uniform(0,1,size=1)
             testrun_2  = getattr(trpath._feffdat, 'pha_feff')
             ylabel     = 'magnitude and phase'
-            label      = 'magnitude' 
+            label      = 'magnitude'
         elif part=='amp':
             baseline_1 = getattr(blpath._feffdat, 'amp')
             testrun_1  = getattr(trpath._feffdat, 'amp')
             ylabel     = 'total amplitude'
-            label      = 'amplitude' 
+            label      = 'amplitude'
         elif part=='phase':
             baseline_1 = getattr(blpath._feffdat, 'pha')
             testrun_1  = getattr(trpath._feffdat, 'pha')
             ylabel     = 'total phase shift'
-            label      = 'phase' 
-        elif part=='lambda':
+            label      = 'phase'
+        elif part=='lam':
             baseline_1 = getattr(blpath._feffdat, 'lam')
             testrun_1  = getattr(trpath._feffdat, 'lam')
             ylabel     = 'mean free path'
-            label      = 'MFP' 
-        elif part=='caps':
+            label      = 'lambda'
+        elif part=='phc':
             baseline_1 = getattr(blpath._feffdat, 'real_phc')
             testrun_1  = getattr(trpath._feffdat, 'real_phc')
             ylabel     = 'central atom phase shift'
-            label      = 'CAPS' 
-        elif part=='redfact':
+            label      = 'phc'
+        elif part=='red_fact':
             baseline_1 = getattr(blpath._feffdat, 'red_fact')
             testrun_1  = getattr(trpath._feffdat, 'red_fact')
             ylabel     = 'reduction factor'
@@ -376,33 +388,32 @@ class Feff85exafsUnitTestGroup(Group):
             ylabel     = 'real part of p(k)'
             label      = 'Re[p(k)]'
         else:
-            if self.verbose: print colored("Unknown choice of parts \"%s\"\nmust be one of (feff|amp|phase|lambda|caps|redfact|rep)\nusing feff" % part,
-                                           'magenta', attrs=['bold'])
+            if self.verbose:
+                print_error("Unknown choice of parts \"%s\"\nmust be one of (feff|amp|phase|lam|phc|red_fact|rep)\nusing feff" % part)
             part       = 'feff'
             baseline_1 = getattr(blpath._feffdat, 'mag_feff')
             testrun_1  = getattr(trpath._feffdat, 'mag_feff')
             baseline_2 = getattr(blpath._feffdat, 'pha_feff')
             testrun_2  = getattr(trpath._feffdat, 'pha_feff')
             ylabel     = 'magnitude and phase'
-            label      = 'magnitude' 
-            
-            
+            label      = 'magnitude'
+
+
         self.rfactor_2 = 0
-        self.rfactor = sum((baseline_1 - testrun_1)**2) / sum(baseline_1**2)
-        if self.verbose: 
-            print colored("\nComparing %s of %s (%s) (using %s)" % (label, nnnndat, "with SCF" if self.doscf else "without SCF", how),
-                          'yellow', attrs=['bold'])
+        self.rfactor = 1000* sum((baseline_1 - testrun_1)**2) / sum(baseline_1**2)
+        if self.verbose:
+            print_warn("\nComparing %s of %s (%s) (using %s)" % (label, nnnndat, "with SCF" if self.doscf else "without SCF", how))
             self.print_geometry(blpath)
-            
-        if self.verbose: 
-            print label + " R-factor = " + colored("%.3f" % self.rfactor, 'green' if self.rfactor < self.epsilon else 'magenta', attrs=['bold'])
+            print_warn("%s:  %f v %f " % (blpath, sum(baseline_1**2) ,  sum(testrun_1**2)))
+
+        if self.verbose:
+            print label + " R-factor = " + test_text("%.9g" % self.rfactor, (self.rfactor < self.epsilon))
         if part=='feff':
-            self.rfactor_2 = sum((testrun_2 - testrun_2)**2) / sum(baseline_2**2)
-            if self.verbose: 
-                color = 'green'  if self.rfactor_2 < self.epsilon else 'magenta'
-                print "phase R-factor = " + colored("%.3f" % self.rfactor_2, color, attrs=['bold'])
+            self.rfactor_2 = sum((baseline_2 - testrun_2)**2) / sum(baseline_2**2)
+            if self.verbose:
+                print "phase R-factor = " + test_text("%.9g" % self.rfactor_2, self.rfactor_2 < self.epsilon)
         if self.verbose: print ""
-        
+
         if self.doplot:
             _newplot(blpath._feffdat.k, baseline_1, _larch=self._larch, label=label+' of baseline',
                      xlabel='wavenumber $\AA^{-1}$', ylabel=ylabel, title=nnnndat, show_legend=True, legend_loc='best')
@@ -410,17 +421,16 @@ class Feff85exafsUnitTestGroup(Group):
             if part=='feff':
                 _plot(blpath._feffdat.k, np.gradient(baseline_2), _larch=self._larch, label='grad(phase of baseline)')
                 _plot(trpath._feffdat.k, np.gradient(testrun_2),  _larch=self._larch, label='grad(phase of test run)')
-                
-        if use_wrapper and self.wrapper_available:
-            unlink(join(self.testrun,  n3nndat))
-            self.sp.clear()
+
+        if use_wrapper:
+            self.sp.reset()
 
         if part=='feff':
             return self.rfactor < self.epsilon and self.rfactor_2 < self.epsilon
         else:
             return self.rfactor < self.epsilon
-            
-            
+
+
     def print_geometry(self, path):
         """
         Print out a table showing the scattering geometry of a path
@@ -431,9 +441,9 @@ class Feff85exafsUnitTestGroup(Group):
             print "\t%-2s  %7.4f  %7.4f  %7.4f  %d" % (atom[0], atom[3], atom[4], atom[5], atom[2])
         print "\t%-2s  %7.4f  %7.4f  %7.4f  %d\n" % (path.geom[0][0], path.geom[0][3], path.geom[0][4],
                                                      path.geom[0][5], path.geom[0][2])
-        
-        
-        
+
+
+
     def s02(self, folder='testrun'):
         """
         Return the value of S02 calculated by the testrun or the baseline.
@@ -444,15 +454,15 @@ class Feff85exafsUnitTestGroup(Group):
             chidat = join(self.testrun, 'chi.dat')
         else:
             chidat = join(self.baseline, 'chi.dat')
-            
+
         with open(chidat, 'r') as searchfile:
             for line in searchfile:
                 m = re.search('S02=(\d\.\d+)', line)
                 if m:
                     return float(m.group(1))
         return -1
-        
-        
+
+
     def radii(self, folder='testrun', radius='muffintin'):
         """
         Return a list of the selected radii for each unique potential
@@ -464,7 +474,7 @@ class Feff85exafsUnitTestGroup(Group):
             chidat = join(self.testrun, 'chi.dat')
         else:
             chidat = join(self.baseline, 'chi.dat')
-            
+
         values = list()
         with open(chidat, 'r') as searchfile:
             for line in searchfile:
@@ -475,8 +485,8 @@ class Feff85exafsUnitTestGroup(Group):
                 if m:
                     values.append(float(m.group(1)))
         return values
-        
-        
+
+
     def feffterms(self, nnnn=1):
         """
         Fetch the various numbers in the feffNNNN.dat header for both
@@ -490,7 +500,7 @@ class Feff85exafsUnitTestGroup(Group):
         nnnndat = "feff%4.4d.dat" % nnnn
         bl      = feffpath(join(self.baseline, nnnndat))
         tr      = feffpath(join(self.testrun,  nnnndat))
-        
+
         termdict = {'edge':   'energy threshold relative to atomic value',
                     'gam_ch': 'core level energy width',
                     'kf':     'k value at Fermi level',
@@ -507,9 +517,9 @@ class Feff85exafsUnitTestGroup(Group):
                                                                       getattr(tr._feffdat, key), same)
             ok = ok and same
         return ok
-        
-        
-        
+
+
+
     def fit(self):
         """
         Perform a canned fit using the baseline and testrun Feff
@@ -522,12 +532,12 @@ class Feff85exafsUnitTestGroup(Group):
         """
         sys.path.append(self.path)
         module = importlib.import_module(self.folder, package=None)
-        
+
         print "\tfitting %s using %s" % (self.folder, 'baseline')
         self.blfit = module.do_fit(self, 'baseline')
         print "\tfitting %s using %s" % (self.folder, 'testrun')
         self.trfit = module.do_fit(self, 'testrun')
-        
+
 
     def fitcompare(self):
         """
@@ -561,15 +571,15 @@ class Feff85exafsUnitTestGroup(Group):
                 this = module.do_fit(self, d, firstshell=self.firstshell, fittest=self.fittest)
                 setattr(self, d, this)
 
-        
+
     def clean(self):
         """
         Remove testrun folder
         """
         if isdir(self.testrun): rmtree(self.testrun)
         self.feffran = False
-        
-        
+
+
 ######################################################################
 
 def ut(folder=None, _larch=None, **kws):
@@ -579,7 +589,7 @@ def ut(folder=None, _larch=None, **kws):
 
     """
     return Feff85exafsUnitTestGroup(folder=folder, _larch=_larch)
-    
+
 def ir(folder=None, _larch=None, **kws):
     """
     _i_mport and _r_un
@@ -588,7 +598,7 @@ def ir(folder=None, _larch=None, **kws):
     utobj=ut(folder)
     utobj.run()
     return utobj
-    
+
 def irc(folder=None, _larch=None, **kws):
     """
     _i_mport, _r_un, and _c_ompare
@@ -598,7 +608,7 @@ def irc(folder=None, _larch=None, **kws):
     utobj.run()
     utobj.compare(1)
     return utobj
-    
+
 def irf(folder=None, _larch=None, **kws):
     """_i_mport, _r_un, and _f_it
 
@@ -607,7 +617,6 @@ def irf(folder=None, _larch=None, **kws):
     utobj.run()
     utobj.fit()
     return utobj
-    
+
 def registerLarchPlugin(): # must have a function with this name!
     return ('f85ut', { 'ut': ut, 'ir': ir, 'irc': irc, 'irf': irf })
-    

--- a/tests/f85ut.py
+++ b/tests/f85ut.py
@@ -15,8 +15,14 @@ from larch import (Group, Parameter, isParameter, param_value,
                    isNamedClass, Interpreter)
 from larch_plugins.xafs.feffdat import feffpath
 from larch_plugins.xafs.feffrunner import feffrunner
-from larch_plugins.xafs.feff8lpath import Feff8L_XAFSPath
 from larch_plugins.wx import (_newplot, _plot)
+
+WRAPPER_AVAILABLE = False
+try:
+    from larch_plugins.xafs.feff8lpath import Feff8L_XAFSPath
+    WRAPPER_AVAILABLE = True
+except:
+    pass
 
 
 WARN_COLOR = 'yellow'
@@ -110,8 +116,8 @@ class Feff85exafsUnitTestGroup(Group):
         self.epsfit     = self.eps3
         self.firstshell = False
         self.fittest    = None
-        self.sp = Feff8L_XAFSPath(_larch=self._larch)
-
+        if WRAPPER_AVAILABLE:
+            self.sp = Feff8L_XAFSPath(_larch=self._larch)
 
     def __repr__(self):
         if not isdir(self.folder):
@@ -183,7 +189,6 @@ class Feff85exafsUnitTestGroup(Group):
             for f in glob.glob("*"):
                 if f.startswith('log'):
                     unlink(f)
-
             if self.verbose:
                 print_warn("\nRan Feff85EXAFS on %s (%s)" % (self.folder, scf))
             self.__testpaths()
@@ -400,7 +405,7 @@ class Feff85exafsUnitTestGroup(Group):
 
 
         self.rfactor_2 = 0
-        self.rfactor = 1000* sum((baseline_1 - testrun_1)**2) / sum(baseline_1**2)
+        self.rfactor = sum((baseline_1 - testrun_1)**2) / sum(baseline_1**2)
         if self.verbose:
             print_warn("\nComparing %s of %s (%s) (using %s)" % (label, nnnndat, "with SCF" if self.doscf else "without SCF", how))
             self.print_geometry(blpath)
@@ -412,6 +417,7 @@ class Feff85exafsUnitTestGroup(Group):
             self.rfactor_2 = sum((baseline_2 - testrun_2)**2) / sum(baseline_2**2)
             if self.verbose:
                 print "phase R-factor = " + test_text("%.9g" % self.rfactor_2, self.rfactor_2 < self.epsilon)
+
         if self.verbose: print ""
 
         if self.doplot:
@@ -422,7 +428,7 @@ class Feff85exafsUnitTestGroup(Group):
                 _plot(blpath._feffdat.k, np.gradient(baseline_2), _larch=self._larch, label='grad(phase of baseline)')
                 _plot(trpath._feffdat.k, np.gradient(testrun_2),  _larch=self._larch, label='grad(phase of test run)')
 
-        if use_wrapper:
+        if use_wrapper and WRAPPER_AVAILABLE:
             self.sp.reset()
 
         if part=='feff':

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,0 +1,193 @@
+## feff85exafs unit testing system using larch
+## see HEADERS/license.h for feff's license information
+
+import os
+import sys
+from os.path import isfile, isdir, join, exists
+import re
+
+from math import isnan
+
+import nose
+import pytest
+
+import larch
+from larch_plugins.xafs.feffdat import feffpath
+from larch_plugins.io import read_ascii
+
+from f85ut import ut
+
+ALL_FOLDERS = ('Copper', 'NiO', 'UO2', 'Zircon', 'ferrocene',
+               'bromoadamantane', 'LCO-para', 'LCO-perp')
+
+class Feff8Test:
+    def __init__(self, folder, verbose=True, doplot=False, doscf=None):
+        if folder not in ALL_FOLDERS:
+            raise ValueError("Must choose one of the available tests:\n  %s\n" % repr(ALL_FOLDERS))
+
+        if doscf is None:
+            envar = os.getenv('FEFF_TEST_SCF', 'False')
+            doscf = envar.lower() in ("yes", "true", "on", "y", "t", "1")
+
+        self.folder = folder
+        self.test = ut(folder)
+        self.test.verbose = verbose
+        self.test.doplot = doplot
+        self.test.doscf = doscf
+
+    def test_feffrun(self):
+        "run feff"
+        self.test.run()
+        scf = 'without SCF'
+        if self.test.doscf:
+            scf = 'with SCF'
+        # f85e.log shouldn't be more than a couple thousand lines long
+        # (ferrocene w/SCF is 1096)
+        with open(join(self.test.testrun, 'f85e.log'), 'r') as log:
+            lines = log.readlines()
+            m = re.search('Done with module 6:', lines[-1])
+        assert m and self.test.available(1), "feff run on %s (%s) not successful" % (self.folder, scf)
+
+
+    def test_feff(self):
+        """check F_eff for each path"""
+        assert self.test.feffran, "no test results found for %s" % self.folder
+        for path in self.test.paths:
+            index = int(path[4:8])
+            for part in ('feff', 'amp', 'phase',
+                         'lam', 'phc', 'red_fact', 'rep'):
+                result = self.test.compare(index, part=part)
+                assert result, "comparison of %s for path %d in %s" % (part, index, self.folder)
+
+    def test_terms(self):
+        "check various quantities computed by feff"
+        assert self.test.feffran, "no test results found for %s" % self.folder
+        for npath in range(1, 10):
+            basefile = join(self.test.baseline, 'feff%4.4i.dat' % npath)
+            if not exists(basefile):
+                continue
+            bl = feffpath(join(self.test.baseline, 'feff%4.4i.dat' % npath))
+            tr = feffpath(join(self.test.testrun,  'feff%4.4i.dat' % npath))
+            for term in ('edge', 'gam_ch', 'kf', 'mu', 'rs_int', 'vint'):
+                tdiff = getattr(bl._feffdat, term) - getattr(tr._feffdat, term)
+                assert abs(tdiff) < 1.e-4, "feff term %s not close enough for %s" % (term, self.folder)
+
+        for radius in ('muffintin', 'norman'):
+            bl = self.test.radii('baseline', radius)
+            tr = self.test.radii('testrun',  radius)
+            assert bl == tr, "list of %s radii are different for %s" % (radius, self.folder)
+        assert self.test.s02() == self.test.s02('baseline'), "s02 calculated incorrectly for %s" % self.folder
+
+    def test_clean(self):
+        """remove the test run"""
+        self.test.clean()
+        assert not isdir(self.test.testrun), "clean up %s calculation not successful" % self.folder
+
+    def test_columns_wrapper(self):
+        assert self.test.feffran, "no test results found for %s" % self.folder
+        msg = "comparison of %s for path %i in %s using wrapper"
+
+        for path in self.test.paths:
+            index = int(path[4:8])
+            for part in ('feff', 'amp', 'phase', 'lam', 'phc', 'red_fact', 'rep'):
+                result = self.test.compare(index, part=part, use_wrapper=True)
+                assert result, msg % (part, index, self.folder)
+
+
+    def test_fit(self):
+        """check various fitting and statistical parameters from a canned fit"""
+        assert self.test.feffran, "no test results found for %s" % self.folder
+
+        test_script = join(self.test.path, self.test.folder+'.py')
+        stat_msg = "statistic %s evaluated inconsistently for %s (%.5f %.5f)"
+        param_msg = "%s of fitting parameter %s evaluated inconsistently for %s (%.5f %.5f)"
+
+        if isfile(test_script):
+            self.test.fit()
+            eps = self.test.epsfit
+            for stat in ('chi_reduced', 'chi_square', 'rfactor'):
+                bl = getattr(self.test.blfit.params, stat)
+                tr = getattr(self.test.trfit.params, stat)
+                close = abs((bl-tr)/bl) < eps
+                assert close, stat_msg % (stat, self.folder, bl, tr)
+
+            for par in self.test.blfit.params.covar_vars:
+                for part in ('value', 'stderr'):
+                    bl = getattr(getattr(self.test.blfit.params, par), part)
+                    tr = getattr(getattr(self.test.trfit.params, par), part)
+                    close = abs((bl-tr)/bl) < eps
+                    assert close, param_msg % (part, par, self.folder, bl, tr)
+
+
+    @pytest.mark.skip(reason="not testing opconsat")
+    def test_feffrun_opconsat(self):
+        oca_ok = self.test.run_opconsat()
+        assert oca_ok, "opconsat run on %s not successful" % folder
+
+    @pytest.mark.skip(reason="not testing opconsat")
+    def test_opconsat(self):
+        check_skip("not checking opconstat")
+        self.test.run_opconsat()
+        for f in self.tests:
+            pass # check_opconsat(f)
+
+
+################################################################################
+
+
+def check_opconsat(folder):
+    orig = read_ascii(join(tests[folder].testrun, "..", "opconsat", "baseline", "exc.dat"), labels='a b c d', _larch=tests[folder]._larch)
+    if not isfile(join(tests[folder].testrun, "exc.dat")):
+        assert False, 'Failed to run opconsat'
+    new  = read_ascii(join(tests[folder].testrun, "exc.dat"), labels='a b c d', _larch=tests[folder]._larch)
+    #show(orig, _larch=self._larch)
+    #show(new, _larch=self._larch)
+    rf1  = sum((orig.a - new.a)**2) / sum(orig.a**2)
+    rf2  = sum((orig.b - new.b)**2) / sum(orig.b**2)
+    rf3  = sum((orig.c - new.c)**2) / sum(orig.c**2)
+    rf4  = sum((orig.d - new.d)**2) / sum(orig.d**2)
+    which = []
+    failed = False
+    if isnan(rf1):
+        which.append('1')
+        failed = True
+    if isnan(rf2):
+        which.append('2')
+        failed = True
+    if isnan(rf3):
+        which.append('3')
+        failed = True
+    if isnan(rf4):
+        which.append('4')
+        failed = True
+    if failed:
+        assert False, "columns of exc.dat are not a number: %s" % ', '.join(which)
+
+    which = []
+    failed = False
+    if rf1 < tests[folder].epsfit:
+        which.append('1')
+        failed = True
+    if rf2 < tests[folder].epsfit:
+        which.append('2')
+        failed = True
+    if rf3 < tests[folder].epsfit:
+        which.append('3')
+        failed = True
+    if rf4 < tests[folder].epsfit:
+        which.append('4')
+        failed = True
+    assert failed, "columns of exc.dat are not equal to baseline: %s" % ', '.join(which)
+
+if __name__ == '__main__':
+    TEST_FOLDERS = ('Copper', 'NiO', 'Zircon', 'ferrocene', 'LCO-para', 'LCO-perp')
+    # TEST_FOLDERS = ('Copper', 'NiO')
+    # TEST_FOLDERS = ALL_FOLDERS
+    for folder in TEST_FOLDERS:
+        t =  Feff8Test(folder)
+        t.test_feffrun()
+        t.test_feff()
+        t.test_terms()
+        t.test_columns_wrapper()
+        t.test_fit()
+        t.test_clean()


### PR DESCRIPTION
this updates the python tests, mostly changing `test_materials.py` to `run_tests.py` and as an effort to try follow the tests in detail.  The basic framework and `f85ut.py` are largely in tact.

This now assumes that the python wrapper to generate Feff8 Path from phase.pad + geometry is in the Larch plugin Feff8l_XAFSPath, with has many changes so as to better match Larch conventions for a Feff6 path.

I didn't try to get the opconsat tests to work....
