### PR TITLE
Add flinkargs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,9 +56,9 @@ src/GENFMT/python/*
 README.html
 
 ## compiled programs
-src/POT/pot
+src/POT/feff8l_pot
 src/POT/libpotph
-src/GENFMT/genfmt
+src/GENFMT/feff8l_genfmt
 src/GENFMT/onepath
 src/GENFMT/feffpath
 wrappers/C/makepath
@@ -67,15 +67,16 @@ wrappers/C/makephases
 wrappers/C/pherr
 wrappers/fortran/makepath
 wrappers/fortran/makepotph
-src/PATH/pathfinder
-src/XSPH/xsph
+src/PATH/feff8l_pathfinder
+src/XSPH/feff8l_xsph
 src/FMS/fms
-src/RDINP/rdinp
-src/FF2X/ff2x
+src/RDINP/feff8l_rdinp
+src/FF2X/feff8l_ff2x
 src/GENFMT/FeffPathWrapper.pm
 src/GENFMT/feffpath_wrap.c
 src/OPCONSAT/opconsat
 src/OPCONSAT/eps2exc
+src/feff6l/feff6l
 
 doc/feff8.aux
 doc/feff8.log

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 export PREFIX  = /usr/local
+export PREFIX =  ${CURDIR}/local_install
 
 export BASEDIR = ${CURDIR}
 export BINDIR  = $(PREFIX)/bin		# installation location for programs

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 export PREFIX  = /usr/local
-# export PREFIX  = ${HOME}/local
 
 export BASEDIR = ${CURDIR}
 export BINDIR  = $(PREFIX)/bin		# installation location for programs
@@ -9,15 +8,20 @@ export INCDIR  = $(PREFIX)/include	# installation location for include files
 ###########################################################################################
 # gcc (tested on Ubuntu linux with gcc 5.4.0, darwin with gcc 6.3)                        #
 ###########################################################################################
-export FORTRAN  = gfortran	## compile Feff's Fortran, including the F90 bits
+
+## compile Feff's Fortran, including the F90 bits
+export FORTRAN  = gfortran
 export SHARED   = -shared
 export FCFLAGS  = -c -O3 -ffree-line-length-none -g -Wall -fPIC
 export FJSON    = -I$(BASEDIR)/src/json-fortran -J$(BASEDIR)/src/json-fortran
+export FLINKARGS =
 
-export CC       = gcc	 	## compile the C wrappers for phases and paths
+## compile the C wrappers for phases and paths
+export CC       = gcc
 export CCFLAGS  = -c -g -fPIC
 
-export F90      = gfortran	## compile json-fortran, which is F2008
+## compile json-fortran, which is F2008
+export F90      = gfortran
 export F90FLAGS = -std=f2008 -c -O2 -fbacktrace -g -Wall -Wextra -Wno-maybe-uninitialized -pedantic -fPIC
 ###########################################################################################
 
@@ -46,6 +50,7 @@ else
     UNAME := $(shell uname -s)
     ifeq ($(UNAME),Darwin)
         SHOBJ = .dylib
+        FLINKARGS =  -headerpad_max_install_names
     endif
 endif
 ###########################################################################################

--- a/src/FF2X/Makefile
+++ b/src/FF2X/Makefile
@@ -23,9 +23,9 @@ archives = ../json-fortran/libjsonfortran$(ARCHV)	\
 ../JSON/libfeffjson$(ARCHV)
 
 
-all:	otherdirs ff2x
+all:	otherdirs feff8l_ff2x$(EXEXT)
 
-ff2x:	$(objects) $(archives)
+feff8l_ff2x$(EXEXT):	$(objects) $(archives)
 	$(FORTRAN) $(objects) $(archives) -o $@
 
 %.o:	%.f
@@ -46,10 +46,10 @@ xscorr.o:	xscorr.f ../HEADERS/const.h ../HEADERS/dim.h
 
 
 clean:
-	$(RM) *.o ff2x
+	$(RM) *.o feff8l_ff2x$(EXEXT)
 
 install:
-	$(COPY) ff2x $(BINDIR)
+	$(COPY) feff8l_ff2x$(EXEXT) $(BINDIR)
 
 otherdirs:
 	$(MAKE) -C ../json-fortran libjsonfortran$(ARCHV)

--- a/src/GENFMT/Makefile
+++ b/src/GENFMT/Makefile
@@ -21,7 +21,7 @@ SHOBJ   ?= .so
 ARCHV   ?= .a
 EXEXT   ?=
 
-all:	otherdirs libfeffgenfmt$(ARCHV) libonepath$(SHOBJ) libfeff8lpath$(SHOBJ) genfmt$(EXEXT)
+all:	otherdirs libfeffgenfmt$(ARCHV) libonepath$(SHOBJ) libfeff8lpath$(SHOBJ) feff8l_genfmt$(EXEXT)
 
 libobj = genfmt_prep.o fmtrxi.o mmtr.o mmtrxi.o import.o rot3i.o sclmz.o setlam.o snlm.o xstar.o trig.o
 
@@ -64,7 +64,7 @@ archives = ../json-fortran/libjsonfortran$(ARCHV)	\
 ../JSON/libfeffjson$(ARCHV)
 
 
-genfmt$(EXEXT):	$(binobj) libfeffgenfmt$(ARCHV) $(archives)
+feff8l_genfmt$(EXEXT):	$(binobj) libfeffgenfmt$(ARCHV) $(archives)
 	$(FORTRAN) $(FLINKARGS) $(binobj) libfeffgenfmt$(ARCHV) $(archives) -o $@
 
 feffpath.o:	feffpath.c feffpath.h
@@ -96,7 +96,7 @@ xstar.o:	xstar.f        ../HEADERS/const.h ../HEADERS/dim.h
 
 
 clean:
-	$(RM) *$(SHOBJ) *.o *$(ARCHV) genfmt$(EXEXT)
+	$(RM) *$(SHOBJ) *.o *$(ARCHV) feff8l_genfmt$(EXEXT)
 
 INSTARCH = @echo "Not installing $(ARCHV) files"
 ifdef INSTALL_ARCHIVES
@@ -104,7 +104,7 @@ INSTARCH = $(COPY) libfeffgenfmt$(ARCHV) $(PREFIX)/lib
 endif
 
 install:
-	$(COPY) genfmt$(EXEXT)      $(BINDIR)
+	$(COPY) feff8l_genfmt$(EXEXT)      $(BINDIR)
 	$(COPY) libonepath$(SHOBJ)  $(LIBDIR)
 	$(COPY) libfeff8lpath$(SHOBJ) $(LIBDIR)
 	$(COPY) feffpath.h          $(INCDIR)

--- a/src/GENFMT/Makefile
+++ b/src/GENFMT/Makefile
@@ -65,8 +65,7 @@ archives = ../json-fortran/libjsonfortran$(ARCHV)	\
 
 
 genfmt$(EXEXT):	$(binobj) libfeffgenfmt$(ARCHV) $(archives)
-	$(FORTRAN) $(binobj) libfeffgenfmt$(ARCHV) $(archives) -o $@
-
+	$(FORTRAN) $(FLINKARGS) $(binobj) libfeffgenfmt$(ARCHV) $(archives) -o $@
 
 feffpath.o:	feffpath.c feffpath.h
 ffmod5.o:	ffmod5.f       ../HEADERS/dim.h                    ../HEADERS/parallel.h

--- a/src/PATH/Makefile
+++ b/src/PATH/Makefile
@@ -22,9 +22,9 @@ archives = ../json-fortran/libjsonfortran$(ARCHV)	\
 ../COMMON/libfeffcom$(ARCHV) ../PAR/libfeffpar$(ARCHV)	\
 ../MATH/libfeffmath$(ARCHV) ../JSON/libfeffjson$(ARCHV)
 
-all:	otherdirs pathfinder$(EXEXT)
+all:	otherdirs feff8l_pathfinder$(EXEXT)
 
-pathfinder$(EXEXT):	$(objects)
+feff8l_pathfinder$(EXEXT):	$(objects)
 	$(FORTRAN) $(FLINKARGS) $(objects) $(archives) -o $@
 
 
@@ -49,10 +49,10 @@ timrep.o:	timrep.f ../HEADERS/dim.h
 
 
 clean:
-	$(RM) *.o pathfinder$(EXEXT)
+	$(RM) *.o feff8l_pathfinder$(EXEXT)
 
 install:
-	$(COPY) pathfinder$(EXEXT) $(BINDIR)
+	$(COPY) feff8l_pathfinder$(EXEXT) $(BINDIR)
 
 otherdirs:
 	$(MAKE) -C ../json-fortran libjsonfortran$(ARCHV)

--- a/src/PATH/Makefile
+++ b/src/PATH/Makefile
@@ -25,7 +25,7 @@ archives = ../json-fortran/libjsonfortran$(ARCHV)	\
 all:	otherdirs pathfinder$(EXEXT)
 
 pathfinder$(EXEXT):	$(objects)
-	$(FORTRAN) $(objects) $(archives) -o $@
+	$(FORTRAN) $(FLINKARGS) $(objects) $(archives) -o $@
 
 
 ccrit.o:	ccrit.f  ../HEADERS/const.h ../HEADERS/dim.h

--- a/src/POT/Makefile
+++ b/src/POT/Makefile
@@ -94,7 +94,7 @@ JSONobj = ../JSON/json_read_libpotph.o ../JSON/json_xsect.o ../JSON/bailout.o ..
 
 
 
-all:	otherdirs libfeffint$(ARCHV) libpotph$(SHOBJ) libfeff8lpotph$(SHOBJ) pot$(EXEXT)
+all:	otherdirs libfeffint$(ARCHV) libpotph$(SHOBJ) libfeff8lpotph$(SHOBJ) feff8l_pot$(EXEXT)
 
 libfeffint$(ARCHV):	istprm.o movrlp.o ovp2mt.o fermi.o sidx.o
 	$(AR) $(ARFLAGS) libfeffint$(ARCHV) istprm.o movrlp.o ovp2mt.o fermi.o sidx.o
@@ -107,7 +107,7 @@ libfeff8lpotph$(SHOBJ):	feffphases.o $(shobjects) $(JSONobj)
 	$(FORTRAN) $(SHARED) feffphases.o $(shobjects) $(JSONobj) -o $@
 
 
-pot$(EXEXT):	$(binobj) $(archives)
+feff8l_pot$(EXEXT):	$(binobj) $(archives)
 	$(FORTRAN) $(FLINKARGS) $(binobj) $(archives) -o $@
 
 
@@ -215,7 +215,7 @@ wrpot.o:	wrpot.f                       ../HEADERS/dim.h
 
 
 clean:
-	$(RM) *$(SHOBJ) *.o *$(ARCHV) *$(SHOBJ) pot$(EXEXT)
+	$(RM) *$(SHOBJ) *.o *$(ARCHV) *$(SHOBJ) feff8l_pot$(EXEXT)
 
 INSTARCH = @echo "Not installing $(ARCHV) files"
 ifdef INSTALL_ARCHIVES
@@ -223,7 +223,7 @@ INSTARCH = $(COPY) libfeffint$(ARCHV) $(PREFIX)/lib
 endif
 
 install:
-	$(COPY) pot$(EXEXT)           $(BINDIR)
+	$(COPY) feff8l_pot$(EXEXT)           $(BINDIR)
 	$(COPY) libpotph$(SHOBJ)      $(LIBDIR)
 	$(COPY) libfeff8lpotph$(SHOBJ) $(LIBDIR)
 	$(COPY) feffphases.h          $(INCDIR)

--- a/src/POT/Makefile
+++ b/src/POT/Makefile
@@ -108,7 +108,7 @@ libfeff8lpotph$(SHOBJ):	feffphases.o $(shobjects) $(JSONobj)
 
 
 pot$(EXEXT):	$(binobj) $(archives)
-	$(FORTRAN) $(binobj) $(archives) -o $@
+	$(FORTRAN) $(FLINKARGS) $(binobj) $(archives) -o $@
 
 
 ../COMMON/fixdsp.o:	../COMMON/fixdsp.f  ../HEADERS/const.h ../HEADERS/dim.h

--- a/src/RDINP/Makefile
+++ b/src/RDINP/Makefile
@@ -20,9 +20,9 @@ archives = ../json-fortran/libjsonfortran$(ARCHV)	\
 ../COMMON/libfeffcom$(ARCHV) ../PAR/libfeffpar$(ARCHV)	\
 ../MATH/libfeffmath$(ARCHV) ../JSON/libfeffjson$(ARCHV)
 
-all:	otherdirs rdinp$(EXEXT)
+all:	otherdirs feff8l_rdinp$(EXEXT)
 
-rdinp$(EXEXT):	$(objects) $(archives)
+feff8l_rdinp$(EXEXT):	$(objects) $(archives)
 	$(FORTRAN) $(FLINKARGS) $(objects) $(archives) -o $@
 
 ffsort.o:	ffsort.f  allinp.h ../HEADERS/const.h ../HEADERS/dim.h ../HEADERS/vers.h ../HEADERS/parallel.h
@@ -37,10 +37,10 @@ wrtjsn.o:	wrtjsn.f  allinp.h                    ../HEADERS/dim.h ../HEADERS/vers
 
 
 clean:
-	$(RM) *.o rdinp$(EXEXT)
+	$(RM) *.o feff8l_rdinp$(EXEXT)
 
 install:
-	$(COPY) rdinp$(EXEXT) $(BINDIR)
+	$(COPY) feff8l_rdinp$(EXEXT) $(BINDIR)
 
 otherdirs:
 	$(MAKE) -C ../json-fortran libjsonfortran$(ARCHV)

--- a/src/RDINP/Makefile
+++ b/src/RDINP/Makefile
@@ -23,7 +23,7 @@ archives = ../json-fortran/libjsonfortran$(ARCHV)	\
 all:	otherdirs rdinp$(EXEXT)
 
 rdinp$(EXEXT):	$(objects) $(archives)
-	$(FORTRAN) $(objects) $(archives) -o $@
+	$(FORTRAN) $(FLINKARGS) $(objects) $(archives) -o $@
 
 ffsort.o:	ffsort.f  allinp.h ../HEADERS/const.h ../HEADERS/dim.h ../HEADERS/vers.h ../HEADERS/parallel.h
 iniall.o:	iniall.f  allinp.h                    ../HEADERS/dim.h

--- a/src/XSPH/Makefile
+++ b/src/XSPH/Makefile
@@ -30,7 +30,7 @@ otherobj = ../FF2X/xscorr.o ../POT/grids.o ../MATH/terpc.o
 all:	otherdirs xsph$(EXEXT)
 
 xsph$(EXEXT):	$(objects) $(archives) $(otherobj)
-	$(FORTRAN) $(objects) $(archives) $(otherobj) -o $@
+	$(FORTRAN) $(FLINKARGS) $(objects) $(archives) $(otherobj) -o $@
 
 ../FF2X/xscorr.o:	../FF2X/xscorr.f ../HEADERS/dim.h ../HEADERS/const.h
 ../POT/grids.o:		../POT/grids.f                    ../HEADERS/const.h

--- a/src/XSPH/Makefile
+++ b/src/XSPH/Makefile
@@ -27,9 +27,9 @@ archives = ../json-fortran/libjsonfortran$(ARCHV)		\
 
 otherobj = ../FF2X/xscorr.o ../POT/grids.o ../MATH/terpc.o
 
-all:	otherdirs xsph$(EXEXT)
+all:	otherdirs feff8l_xsph$(EXEXT)
 
-xsph$(EXEXT):	$(objects) $(archives) $(otherobj)
+feff8l_xsph$(EXEXT):	$(objects) $(archives) $(otherobj)
 	$(FORTRAN) $(FLINKARGS) $(objects) $(archives) $(otherobj) -o $@
 
 ../FF2X/xscorr.o:	../FF2X/xscorr.f ../HEADERS/dim.h ../HEADERS/const.h
@@ -63,10 +63,10 @@ xsph.o:		xsph.f    ../HEADERS/dim.h ../HEADERS/const.h
 
 
 clean:
-	$(RM) *.o xsph$(EXEXT)
+	$(RM) *.o feff8l_xsph$(EXEXT)
 
 install:
-	$(COPY) xsph$(EXEXT) $(BINDIR)
+	$(COPY) feff8l_xsph$(EXEXT) $(BINDIR)
 
 otherdirs:
 	$(MAKE) -C ../json-fortran libjsonfortran$(ARCHV)

--- a/src/feff6l/Makefile
+++ b/src/feff6l/Makefile
@@ -34,7 +34,7 @@ archives =
 all:	feff6l
 
 feff6l:	$(objects)
-	$(FORTRAN) $(objects) -o $@
+	$(FORTRAN) $(FLINKARGS) $(objects) -o $@
 
 %.o:	%.f
 	$(FORTRAN) $(FCFLAGS) -o $@ $<

--- a/src/feff6l/Makefile
+++ b/src/feff6l/Makefile
@@ -31,19 +31,19 @@ objects= feff.o rdinp.o chopen.o mkptz.o setgam.o terp.o potph.o rpotph.o \
 
 archives =
 
-all:	feff6l
+all:	feff6l$(EXEXT)
 
-feff6l:	$(objects)
+feff6l$(EXEXT):	$(objects)
 	$(FORTRAN) $(FLINKARGS) $(objects) -o $@
 
 %.o:	%.f
 	$(FORTRAN) $(FCFLAGS) -o $@ $<
 
 clean:
-	$(RM) *.o feff6l
+	$(RM) *.o feff6l$(EXEXT)
 
 install:
-	$(COPY) feff6l $(BINDIR)
+	$(COPY) feff6l$(EXEXT) $(BINDIR)
 
 otherdirs:
 

--- a/src/feff6l/arrays.h
+++ b/src/feff6l/arrays.h
@@ -6,46 +6,68 @@ c        ihole	hole code of absorbing atom
 c        iph=0 for central atom
 c        ifr=0 for central atom
 
-c     Specific atom input data
-      dimension iphat(natx)	!given specific atom, which unique pot?
-      dimension rat(3,natx)	!cartesian coords of specific atom
+c  Specific atom input data
+c     given specific atom, which unique pot?
+      dimension iphat(natx)
 
-c     Unique potential input data
-      dimension iatph(0:nphx)	!given unique pot, which atom is model?
-				!(0 if none specified for this unique pot)
-      dimension ifrph(0:nphx)	!given unique pot, which free atom?
-      dimension xnatph(0:nphx)	!given unique pot, how many atoms are there 
-				!of this type? (used for interstitial calc)
-      character*6 potlbl(0:nphx)	!label for user convienence
+c     cartesian coords of specific atom
+      dimension rat(3,natx)
 
-      dimension folp(0:nphx)	!overlap factor for rmt calculation
-      dimension novr(0:nphx)	!number of overlap shells for unique pot
-      dimension iphovr(novrx,0:nphx)	!unique pot for this overlap shell
-      dimension nnovr(novrx,0:nphx)	!number of atoms in overlap shell
-      dimension rovr(novrx,0:nphx)	!r for overlap shell
+c Unique potential input data
+c     given unique pot, which atom is model?
+c     (0 if none specified for this unique pot)
+      dimension iatph(0:nphx)
 
-c     Free atom data
-      dimension ion(0:nfrx)	!ionicity, input
-      dimension iz(0:nfrx)	!atomic number, input
+c     given unique pot, which free atom?
+      dimension ifrph(0:nphx)
 
-c     ATOM output
+c     given unique pot, how many atoms are there
+c     of this type? (used for interstitial calc)
+      dimension xnatph(0:nphx)
+
+c     label for user convienence
+      character*6 potlbl(0:nphx)
+
+c     overlap factor for rmt calculation
+      dimension folp(0:nphx)
+
+c     number of overlap shells for unique pot
+      dimension novr(0:nphx)
+
+c     unique pot for this overlap shell
+      dimension iphovr(novrx,0:nphx)
+
+c     number of atoms in overlap shell
+      dimension nnovr(novrx,0:nphx)
+
+c     r for overlap shell
+      dimension rovr(novrx,0:nphx)
+
+c Free atom data
+c     ionicity, input  ,  atomic number, input
+      dimension ion(0:nfrx),  iz(0:nfrx)
+
+c ATOM output
 c     Note that ATOM output is dimensioned 251, all other r grid
 c     data is set to nrptx, currently 250
-      dimension rho(251,0:nfrx)		!density*4*pi
-      dimension vcoul(251,0:nfrx)	!coulomb potential
+
+c     density*4*pi, coulomb potential
+      dimension rho(251,0:nfrx), vcoul(251,0:nfrx)
 
 c     Overlap calculation results
-      dimension edens(nrptx,0:nphx)	!overlapped density*4*pi
-      dimension vclap(nrptx,0:nphx) 	!overlapped coul pot
-      dimension vtot (nrptx,0:nphx)	!overlapped total potential
+c     overlapped density*4*pi, 	overlapped coul pot
+      dimension edens(nrptx,0:nphx), vclap(nrptx,0:nphx)
+c     overlapped total potential
+      dimension vtot(nrptx,0:nphx)
 
 c     Muffin tin calculation results
-      dimension imt(0:nphx)	!r mesh index just inside rmt
-      dimension inrm(0:nphx)	!r mesh index just inside rnorman
-      dimension rmt(0:nphx)	!muffin tin radius
-      dimension rnrm(0:nphx)	!norman radius
+c     r mesh index just inside rmt, r mesh index just inside rnorman
+      dimension imt(0:nphx),  inrm(0:nphx)
+c     muffin tin radius, norman radius
+      dimension rmt(0:nphx), rnrm(0:nphx)
 
 c     PHASE output
-      complex*16 eref(nex)		!interstitial energy ref
-      complex*16 ph(nex,ltot+1,0:nphx)	!phase shifts
-      dimension lmax(0:nphx)		!number of ang mom levels
+c     interstitial energy ref, phase shifts
+      complex*16 eref(nex), ph(nex,ltot+1,0:nphx)
+c     number of ang mom levels
+      dimension lmax(0:nphx)

--- a/src/feff6l/echo.f
+++ b/src/feff6l/echo.f
@@ -22,7 +22,7 @@ c TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 c SOFTWARE OR THE USE OR OTHER DEALINGS IN THIS SOFTWARE.
 c//////////////////////////////////////////////////////////////////////
 c
-c dump string to standard output 
+c dump string to standard output
        implicit none
        include 'echo.h'
        character*(*) str,form*8
@@ -36,7 +36,7 @@ c end  subroutine echo
 c dump string to screen with "$" format
 c
 c i_echo
-c  0   echo to buffer 
+c  0   echo to buffer
 c  1   echo to screen
 c  2   echo to open echo_file (if open)
 c  3   echo to screen and open echo_file (if open)
@@ -51,7 +51,7 @@ c
        n   = max(1, istrln(out))
        if (i_echo.eq.0) then
           call echo_push(out)
-       else 
+       else
           if (mod(i_echo,2).eq.1) write(*,frm) out(1:n)
           if ((i_echo.ge.2).and.(lun_echo.ge.1))
      $         write(lun_echo, ffrm) out(1:n)
@@ -94,19 +94,19 @@ c initialize echo lines
        implicit none
        include 'echo.h'
        character*(*) s
-       integer  iex, ier, i, istrln
+       integer  iex, ier, istrln
        external istrln
        call close_echofile()
-       
+
        lun_echo = 19
        echo_file = s(1:istrln(s))
        call triml(echo_file)
-       
+
        call openfl(lun_echo, echo_file, 'unknown', iex, ier)
        if (i_echo.eq.0) i_echo = 2
-       if (i_echo.eq.1) i_echo = 3  
+       if (i_echo.eq.1) i_echo = 3
 cc       print*, ' done ' , i_echo
-c        
+c
        return
        end
 
@@ -158,22 +158,22 @@ c  end subroutine echo_pop
 
 c
 c routines to initialize and use a 'stop file'
-c that is, do 
+c that is, do
 c         call fstop_init('stopfile.err')
-c early on, and replace subsequent 
+c early on, and replace subsequent
 c         stop 'problem at line xxx'
 c with
 c         call fstop('problem at line xxx')
 c
-c the error file will contain the error message 
+c the error file will contain the error message
 c and will exist only if fstop() has been called.
 c that is, fstop_init() erases the stop file.
-c  
+c
        subroutine fstop_init(s)
        character*(*) s
        character*32 stopfilename
        common /stop_file/ stopfilename
-       integer istrln,i
+       integer istrln
        external istrln
        stopfilename = s
        call triml(stopfilename)
@@ -212,21 +212,21 @@ c
 
        subroutine warn(i,s)
 c
-c set &status value and write string to echo buffer       
+c set &status value and write string to echo buffer
        integer i
        character*(*) s
        call echo(s)
        call set_status(i)
-       return 
+       return
        end
 
        subroutine set_status(i)
 c
-c set &status value 
-       integer i, ic
+c set &status value
+       integer i
        double precision getsca, xc, xi
        xi = i * 1.d0
        xc = getsca('&status',0)
        if (xi .gt. xc) call setsca('&status',xi)
-       return 
+       return
        end

--- a/src/feff6l/lambda.h
+++ b/src/feff6l/lambda.h
@@ -1,6 +1,9 @@
-      common /lambda/  
-     4   mlam(lamtot), 	!mu for each lambda
-     5   nlam(lamtot),	!nu for each lambda
-     1   lamx, 		!max lambda in problem
-     2   laml0x, 	!max lambda for vectors involving absorbing atom
-     3   mmaxp1, nmax 	!max mu in problem + 1, max nu in problem
+c  common /lambda/  :
+c     mlam(lamtot), 	!mu for each lambda
+c     nlam(lamtot),	!nu for each lambda
+c     lamx, 		!max lambda in problem
+c     laml0x, 	!max lambda for vectors involving absorbing atom
+c     mmaxp1, nmax 	!max mu in problem + 1, max nu in problem
+
+      common /lambda/ mlam(lamtot), nlam(lamtot),
+     $ lamx, laml0x, mmaxp1, nmax

--- a/src/feff6l/pdata.h
+++ b/src/feff6l/pdata.h
@@ -1,5 +1,5 @@
 c     Note that leg nleg is the leg ending at the central atom, so that
-c     ipot(nleg) is central atom potential, rat(nleg) position of 
+c     ipot(nleg) is central atom potential, rat(nleg) position of
 c     central atom.
 c     Central atom has ipot=0
 c     For later convience, rat(,0) and ipot(0) refer to the central
@@ -8,28 +8,40 @@ c     atom, and are the same as rat(,nleg), ipot(nleg).
 c     text and title arrays include carriage control
       character*80 text, title
       character*6  potlbl
-      common /str/ text(40),	!text header from potph
-     1             title(5),	!title from paths.dat
-     1             potlbl(0:npotx)	! potential labels for output
+
+c common /str/:
+c text header from potph
+c title from paths.dat
+c potential labels for output
+
+      common /str/ text(40), title(5), potlbl(0:npotx)
 
       complex*16 ph, eref
-      common /pdata/
-     1 ph(nex,ltot+1,0:npotx),	!complex phase shifts,
-     1					!central atom ipot=0
-     1 rat(3,0:legtot+1),		!position of each atom, code units(bohr)
-     1 eref(nex),		!complex energy reference
-     1 em(nex),		!energy mesh
-     1 ri(legtot), beta(legtot+1), eta(0:legtot+1), !r, beta, eta for each leg
-     1 deg, rnrmav, xmu, edge,	!(output only)
-     1 lmax(nex,0:npotx),	!max l with non-zero phase for each energy
-     1 ipot(0:legtot),	!potential for each atom in path
-     1 iz(0:npotx),	!atomic number (output only)
-     1 ltext(40), ltitle(5),	!length of each string
-     1 nsc, nleg,	!nscatters, nlegs (nleg = nsc+1)
-     1 npot, ne,	!number of potentials, energy points
-     1 ik0,		!index of energy grid corresponding to k=0 (edge)
-     1 ipath, 	!index of current path (output only)
-     1 ihole,	!(output only)
-     1 l0, il0,	!lfinal and lfinal+1 (used for indices)
-     1 lmaxp1,	!largest lmax in problem + 1
-     1 ntext, ntitle	!number of text and title lines
+
+
+c     common /pdata/:
+c ph(nex,ltot+1,0:npotx),	!complex phase shifts,
+c                          !central atom ipot=0
+c rat(3,0:legtot+1),		!position of each atom, code units(bohr)
+c eref(nex),		!complex energy reference
+c em(nex),		!energy mesh
+c ri(legtot), beta(legtot+1), eta(0:legtot+1), !r, beta, eta for each leg
+c deg, rnrmav, xmu, edge,	!(output only)
+c lmax(nex,0:npotx),	!max l with non-zero phase for each energy
+c ipot(0:legtot),	!potential for each atom in path
+c iz(0:npotx),	!atomic number (output only)
+c ltext(40), ltitle(5),	!length of each string
+c nsc, nleg,	!nscatters, nlegs (nleg = nsc+1)
+c npot, ne,	!number of potentials, energy points
+c ik0,		!index of energy grid corresponding to k=0 (edge)
+c ipath, 	!index of current path (output only)
+c ihole,	!(output only)
+c l0, il0,	!lfinal and lfinal+1 (used for indices)
+c lmaxp1,	!largest lmax in problem + 1
+c ntext, ntitle	!number of text and title lines
+
+      common /pdata/ ph(nex,ltot+1,0:npotx), rat(3,0:legtot+1),
+     $     eref(nex), em(nex), ri(legtot), beta(legtot+1),
+     $     eta(0:legtot+1), deg, rnrmav, xmu, edge, lmax(nex,0:npotx),
+     $     ipot(0:legtot), iz(0:npotx), ltext(40), ltitle(5), nsc, nleg,
+     $     npot, ne, ik0, ipath, ihole, l0, il0, lmaxp1, ntext, ntitle


### PR DESCRIPTION
This adds `FLINKARGS` for use in linking the Feff8l executable files.  The motivation is to be able to use a `-headerpad_max_install_names` option on Darwin to better allow the Mac-only utility `install_name_tool` to later change `RPATH` (that is, where they will be able to find Fortran dynamic libs) of these executable files.   The not-quite-standard `patchelf` on Linux is similar, but appears to not need such a flag set.

This PR makes a few small additional changes:
   a) default for `PREFIX` is changed to `${CURDIR}/local_install` so that default install is local and does not assume admin privileges.
   b) some non-code-changing cleanups of Feff6l, especially end-of-line comments in header files which spew warnings.
   c) add `feff8l_` prefix to the installed executable binaries (so we install `feff8l_pot`, instead of `pot` (it may be legal in Seattle,  but not everywhere else ;)).

