### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Feff8L
 ======
 
-[![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.20629.svg)](http://dx.doi.org/10.5281/zenodo.20629)
+[![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.20629.svg)](https://doi.org/10.5281/zenodo.20629)
 
 
 Feff8L: Open Source theoretical EXAFS calculations

--- a/src/ATOM/README.md
+++ b/src/ATOM/README.md
@@ -3,7 +3,7 @@
 
 This directory contains various routines for single configuration
 atomic calculations described in
-[Ankudinov, Zabinsky, Rehr, Comp. Phys. Comm. 98, pp.359-364 (1996)](http://dx.doi.org/10.1016/0010-4655%2896%2900097-5).
+[Ankudinov, Zabinsky, Rehr, Comp. Phys. Comm. 98, pp.359-364 (1996)](https://doi.org/10.1016/0010-4655%2896%2900097-5).
 
 All routines in this directory are covered by the [LICENSE](../HEADERS/license.h)
 

--- a/src/EXCH/README.md
+++ b/src/EXCH/README.md
@@ -7,7 +7,7 @@ and exchange-correlation potentials.
 All routines in this directory are covered by the [LICENSE](../HEADERS/license.h)
 
 [Ankudinov and Rehr, Non-Local Self-Energy Models for XAS](https://doi.org/10.1051/jp4/1997099)
-[Rehr, Kas, Prange, Sorini, Takimoto, Vila, Ab initio theory and calculations of X-ray spectra](http://dx.doi.org/10.1016/j.crhy.2008.08.004)
+[Rehr, Kas, Prange, Sorini, Takimoto, Vila, Ab initio theory and calculations of X-ray spectra](https://doi.org/10.1016/j.crhy.2008.08.004)
 
 # Simple static analysis
 

--- a/src/GENFMT/README.md
+++ b/src/GENFMT/README.md
@@ -3,7 +3,7 @@
 
 This directory contains routines for generalized F matrix
 calculations, as described in
-[the 1990 Rehr-Albers paper](http://dx.doi.org/10.1103/PhysRevB.41.8139).
+[the 1990 Rehr-Albers paper](https://doi.org/10.1103/PhysRevB.41.8139).
 
 All routines in this directory are covered by the [LICENSE](../HEADERS/license.h)
 

--- a/src/OPCONSAT/README.md
+++ b/src/OPCONSAT/README.md
@@ -3,7 +3,7 @@
 
 This directory contains routines for the many-pole self-energy model
 using the optical constants: atomic approximation model.  See
-[the 2007 Kas, et al. paper](http://dx.doi.org/10.1103/PhysRevB.76.195116).
+[the 2007 Kas, et al. paper](https://doi.org/10.1103/PhysRevB.76.195116).
 
 The original Fortran 77 and Fortran 90 routines in this directory are
 covered by the [LICENSE](../HEADERS/license.h).

--- a/tests/LCO-para/README.md
+++ b/tests/LCO-para/README.md
@@ -13,9 +13,9 @@ the LCO-perp test which uses the same material to test polarization
 and ellipticipty.
 
 Structure from
-[Radaelli at al.](http://dx.doi.org/10.1103/PhysRevB.49.4163).
+[Radaelli at al.](https://doi.org/10.1103/PhysRevB.49.4163).
 EXAFS analysis from
-[Haskel, et al.](http://dx.doi.org/10.1103/PhysRevB.56.R521)
+[Haskel, et al.](https://doi.org/10.1103/PhysRevB.56.R521)
 
 ![Ball and stick figure of La2CuO4 from Haskel, et al. ](LCO.png)
 

--- a/tests/LCO-perp/README.md
+++ b/tests/LCO-perp/README.md
@@ -13,9 +13,9 @@ the LCO-para test which uses the same material to test polarization
 without ellipticipty.
 
 Structure from
-[Radaelli at al.](http://dx.doi.org/10.1103/PhysRevB.49.4163).
+[Radaelli at al.](https://doi.org/10.1103/PhysRevB.49.4163).
 EXAFS analysis from
-[Haskel, et al.](http://dx.doi.org/10.1103/PhysRevB.56.R521)
+[Haskel, et al.](https://doi.org/10.1103/PhysRevB.56.R521)
 
 ![Ball and stick figure of La2CuO4 from Haskel, et al. ](LCO.png)
 

--- a/tests/NiO/README.md
+++ b/tests/NiO/README.md
@@ -9,7 +9,7 @@ The XAS data are measured at the Ni K edge.
 
 The NiO sample was kindly provided by Neil Hyatt and Martin Stennett,
 Sheffield University and measured by Bruce at NSLS X23A2.
-See [DOI: 10.1107/S1600577515013521](http://dx.doi.org/10.1107/S1600577515013521).
+See [DOI: 10.1107/S1600577515013521](https://doi.org/10.1107/S1600577515013521).
 
 ![Ball and stick figure of rock-salt NiO](NiO.png)
 

--- a/tests/UO2/README.md
+++ b/tests/UO2/README.md
@@ -9,7 +9,7 @@ system.
 
 The nonparticle uraninite data was measured at APS 10ID and kindly
 provided by Shelly Kelly.  The data test follows her fitting model
-from [DOI: 10.1021/es0208409](http://dx.doi.org/10.1021/es0208409).
+from [DOI: 10.1021/es0208409](https://doi.org/10.1021/es0208409).
 
 
 ![Ball and stick figure of uraninite](uraninite.gif)

--- a/tests/ferrocene/README.md
+++ b/tests/ferrocene/README.md
@@ -5,7 +5,7 @@ computation.
 
 This is a ferrocene-based macrocycle, see Dinnebier et al,
 Organometallics 2001, 20, 5642-5647
-[doi:10.1021/om0105066](http://dx.doi.org/10.1021/om0105066).
+[doi:10.1021/om0105066](https://doi.org/10.1021/om0105066).
 Ferrocene is an example of a transition metal carbide with an odd,
 low-symmetry, disordered local coordination environment.  The Fe atom
 is surrounded by 10 carbon atoms at distances ranging from 2.02642


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) and Zenodo started using it for its badges as well. Accordingly, this PR updates all DOI links.

Cheers!